### PR TITLE
thin 1.6.3 can use --ssl-disable-verify option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,7 +489,7 @@ GEM
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
-    thin (1.6.2)
+    thin (1.6.3)
       daemons (>= 1.0.9)
       eventmachine (>= 1.0.0)
       rack (>= 1.0.0)


### PR DESCRIPTION
This is necessary to correctly use ssl with thin, this option isn't active in 1.6.2. but only in 1.6.3
Whitout this option, browsers ask "Select a certificate" when access the app.