### PR TITLE
#1437 All day events should have time set automatically and not displayed

### DIFF
--- a/app/assets/javascripts/democracy.js
+++ b/app/assets/javascripts/democracy.js
@@ -367,20 +367,14 @@ function start_end_fdatetimepicker(start, end, min_minutes, suggested_minutes) {
 
 function fdatetimepicker_only_date(start, end) {
   start.fdatetimepicker('pickOnlyDate');
+  start.fdatetimepicker('setBeginOfDay');
   end.fdatetimepicker('pickOnlyDate');
+  end.fdatetimepicker('setEndOfDay');
 }
 
 function fdatetimepicker_date_and_time(start, end) {
   start.fdatetimepicker('pickDateAndTime');
   end.fdatetimepicker('pickDateAndTime');
-}
-
-function fdatetimepicker_begin_of_day(e) {
-  e.fdatetimepicker('setBeginOfDay');
-}
-
-function fdatetimepicker_end_of_day(e) {
-  e.fdatetimepicker('setEndOfDay');
 }
 
 function select2town(element) {

--- a/app/assets/javascripts/democracy.js
+++ b/app/assets/javascripts/democracy.js
@@ -365,6 +365,23 @@ function start_end_fdatetimepicker(start, end, min_minutes, suggested_minutes) {
         });
 }
 
+function fdatetimepicker_only_date(start, end) {
+  start.fdatetimepicker('pickOnlyDate');
+  end.fdatetimepicker('pickOnlyDate');
+}
+
+function fdatetimepicker_date_and_time(start, end) {
+  start.fdatetimepicker('pickDateAndTime');
+  end.fdatetimepicker('pickDateAndTime');
+}
+
+function fdatetimepicker_begin_of_day(e) {
+  e.fdatetimepicker('setBeginOfDay');
+}
+
+function fdatetimepicker_end_of_day(e) {
+  e.fdatetimepicker('setEndOfDay');
+}
 
 function select2town(element) {
     element.select2({

--- a/app/assets/javascripts/foundation-datetimepicker.js
+++ b/app/assets/javascripts/foundation-datetimepicker.js
@@ -312,6 +312,30 @@
             });
         },
 
+        pickOnlyDate: function (e) {
+          this.minView = 2;
+          this.viewSelect = 2;
+          this.setFormat('yyyy-mm-dd');
+        },
+
+        pickDateAndTime: function (e) {
+          this.minView = 0;
+          this.viewSelect = 0;
+          this.setFormat('yyyy-mm-dd hh:ii');
+        },
+
+        setBeginOfDay: function (e) {
+          this.date.setUTCHours(0);
+          this.date.setUTCMinutes(0);
+          this._setDate(this.date);
+        },
+
+        setEndOfDay: function (e) {
+          this.date.setUTCHours(23);
+          this.date.setUTCMinutes(59);
+          this._setDate(this.date);
+        },
+
         remove: function () {
             this._detachEvents();
             this.picker.remove();

--- a/app/assets/javascripts/foundation-datetimepicker.js
+++ b/app/assets/javascripts/foundation-datetimepicker.js
@@ -315,13 +315,13 @@
         pickOnlyDate: function (e) {
           this.minView = 2;
           this.viewSelect = 2;
-          this.setFormat('yyyy-mm-dd');
+          this.setFormat(Airesis.i18n.datepicker.dateformat);
         },
 
         pickDateAndTime: function (e) {
           this.minView = 0;
           this.viewSelect = 0;
-          this.setFormat('yyyy-mm-dd hh:ii');
+          this.setFormat(Airesis.i18n.datepicker.datetimeformat);
         },
 
         setBeginOfDay: function (e) {

--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -175,7 +175,5 @@ $ ->
   $(document).on 'change', '#event_all_day', ->
     if $(this).is(':checked')
       fdatetimepicker_only_date $('#event_starttime'), $("#event_endtime")
-      fdatetimepicker_begin_of_day $('#event_starttime')
-      fdatetimepicker_end_of_day $("#event_endtime")
     else
       fdatetimepicker_date_and_time $('#event_starttime'), $("#event_endtime")

--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -170,3 +170,12 @@ $ ->
   #executes page specific js
   page = $('body').data('page')
   execute_page_js page
+
+  #select fdatetimepicker mode in according to All day checkbox
+  $(document).on 'change', '#event_all_day', ->
+    if $(this).is(':checked')
+      fdatetimepicker_only_date $('#event_starttime'), $("#event_endtime")
+      fdatetimepicker_begin_of_day $('#event_starttime')
+      fdatetimepicker_end_of_day $("#event_endtime")
+    else
+      fdatetimepicker_date_and_time $('#event_starttime'), $("#event_endtime")

--- a/app/assets/javascripts/per_page/events/edit.coffee
+++ b/app/assets/javascripts/per_page/events/edit.coffee
@@ -6,6 +6,8 @@ window.EventsEdit =
     @initMapManager()
     if EventsEdit.votation
       @showPlace('2')
+    if $('#event_all_day').is(':checked')
+      fdatetimepicker_only_date $('#event_starttime'), $("#event_endtime")
   showPlace: (value)->
     switch value
       when '2'  #votazione

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,6 +21,8 @@ class Event < ActiveRecord::Base
 
   accepts_nested_attributes_for :meeting
 
+  before_validation :set_all_day_time
+
   scope :visible, -> { where(private: false) }
   scope :not_visible, -> { where(private: true) }
   scope :vote_period, ->(starttime = nil) { where(['event_type_id = ? AND starttime > ?', 2, starttime || Time.now]).order('starttime asc') }
@@ -192,6 +194,13 @@ class Event < ActiveRecord::Base
 
   def end_votation
     proposals.each(&:close_vote_phase)
+  end
+
+  def set_all_day_time
+    if all_day
+      self.starttime = self.starttime.beginning_of_day
+      self.endtime = self.endtime.end_of_day
+    end
   end
 
   protected

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -197,10 +197,13 @@ class Event < ActiveRecord::Base
   end
 
   def set_all_day_time
-    if all_day
-      self.starttime = self.starttime.beginning_of_day
-      self.endtime = self.endtime.end_of_day
-    end
+    return unless all_day
+    self.starttime = starttime.beginning_of_day
+    self.endtime = endtime.end_of_day
+  end
+
+  def datetime_format
+    all_day? ? :from_long_date : :from_long_date_time
   end
 
   protected

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -32,12 +32,12 @@
           <div style="float:left;margin-top: 10px;">
             <meta itemprop="startDate" content="<%= l @event.starttime, format: '%Y-%m-%dT%H:%M' %>">
             <b>
-              <%= l @event.starttime, format: :from_long_date_time %>
+              <%= l @event.starttime, format: @event.all_day? ? :from_long_date : :from_long_date_time %>
             </b>
 
             <div style="margin-top:5px;"></div>
             <b>
-              <%= I18n.localize(@event.endtime, format: :until_long_date_time) %>
+              <%= I18n.localize(@event.endtime, format: @event.all_day? ? :until_long_date : :until_long_date_time) %>
             </b>
           </div>
           <div class="clearboth"></div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -32,12 +32,12 @@
           <div style="float:left;margin-top: 10px;">
             <meta itemprop="startDate" content="<%= l @event.starttime, format: '%Y-%m-%dT%H:%M' %>">
             <b>
-              <%= l @event.starttime, format: @event.all_day? ? :from_long_date : :from_long_date_time %>
+              <%= l @event.starttime, format: @event.datetime_format %>
             </b>
 
             <div style="margin-top:5px;"></div>
             <b>
-              <%= I18n.localize(@event.endtime, format: @event.all_day? ? :until_long_date : :until_long_date_time) %>
+              <%= I18n.localize(@event.endtime, format: @event.datetime_format) %>
             </b>
           </div>
           <div class="clearboth"></div>

--- a/config/locales/dates/dates.bs-BA.yml
+++ b/config/locales/dates/dates.bs-BA.yml
@@ -87,6 +87,8 @@ bs:
       long_date_time: '%A %d %B %Y u %I:%M %p'
       from_long_date_time: 'Od %A %d %B %Y u %I:%M %p'
       until_long_date_time: 'Do %A %d %B %Y u %I:%M %p'
+      from_long_date: 'Od %A %d %B %Y'
+      until_long_date: 'Do %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a u %I:%M %p'

--- a/config/locales/dates/dates.de-DE.yml
+++ b/config/locales/dates/dates.de-DE.yml
@@ -87,6 +87,8 @@ de:
       long_date_time: '%A %d %B %Y at %I:%M %p'
       from_long_date_time: 'Von %A %d %B %Y um %I:%M %p'
       until_long_date_time: 'Bis %A %d %B %Y um %I:%M %p'
+      from_long_date: 'Von %A %d %B %Y'
+      until_long_date: 'Bis %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a at %I:%M %p'

--- a/config/locales/dates/dates.el-GR.yml
+++ b/config/locales/dates/dates.el-GR.yml
@@ -87,6 +87,8 @@ el:
       long_date_time: '%A %d %B %Y σε %I:%M %p'
       from_long_date_time: 'Από %A %d %B %Y σε %I:%M %p'
       until_long_date_time: 'Την %A %d %B %Y στις %I:%M %p'
+      from_long_date: 'Από %A %d %B %Y'
+      until_long_date: 'Την %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a στις %I:%M %p'

--- a/config/locales/dates/dates.en-US.yml
+++ b/config/locales/dates/dates.en-US.yml
@@ -60,6 +60,8 @@ en-US:
       long_date_time: "%A %B %d %Y at %I:%M %p"
       from_long_date_time: "From %A %B %d %Y at %I:%M %p"
       until_long_date_time: "To %A %B %d %Y at %I:%M %p"
+      from_long_date: "From %A %B %d %Y"
+      until_long_date: "To %A %B %d %Y"
       two_rows: "%b %d, %Y <br/> %I:%M %p"
       weekday: "%A"
       month: "%B"

--- a/config/locales/dates/dates.en.yml
+++ b/config/locales/dates/dates.en.yml
@@ -92,6 +92,8 @@ en:
      long_date_time: "%A %d %B %Y at %I:%M %p"
      from_long_date_time: "From %A %d %B %Y at %I:%M %p"
      until_long_date_time: "To %A %d %B %Y at %I:%M %p"
+     from_long_date: "From %A %d %B %Y"
+     until_long_date: "To %A %d %B %Y"
      short: "%d %b %Y"
      two_rows: "%d %b %Y <br/> %I:%M %p"
      weekday: "%a at %I:%M %p"

--- a/config/locales/dates/dates.es-AR.yml
+++ b/config/locales/dates/dates.es-AR.yml
@@ -65,6 +65,8 @@ es-AR:
       long_date_time: '%A %d %B %Y at %I:%M %p'
       from_long_date_time: 'From %A %d %B %Y at %I:%M %p'
       until_long_date_time: 'To %A %d %B %Y at %I:%M %p'
+      from_long_date: 'From %A %d %B %Y'
+      until_long_date: 'To %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a at %I:%M %p'

--- a/config/locales/dates/dates.es-CL.yml
+++ b/config/locales/dates/dates.es-CL.yml
@@ -60,6 +60,8 @@ es-CL:
       long_date_time: '%A %d %B %Y at %I:%M %p'
       from_long_date_time: 'From %A %d %B %Y at %I:%M %p'
       until_long_date_time: 'To %A %d %B %Y a %I:%M %p'
+      from_long_date: 'From %A %d %B %Y'
+      until_long_date: 'To %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a en %I: %M %p'

--- a/config/locales/dates/dates.es-EC.yml
+++ b/config/locales/dates/dates.es-EC.yml
@@ -54,6 +54,8 @@ es-EC:
       long_date_time: '%A %d %B %Y a las %H:%M'
       from_long_date_time: 'Desde %A %d %B %Y a las %H:%M'
       until_long_date_time: 'Hasta %A %d %B %Y a las %H:%M'
+      from_long_date: 'Desde %A %d %B %Y'
+      until_long_date: 'Hasta %A %d %B %Y'
       weekday: '%A'
       textfield: '%d/%m/%Y %H:%M'
   datetime:

--- a/config/locales/dates/dates.es-ES.yml
+++ b/config/locales/dates/dates.es-ES.yml
@@ -87,6 +87,8 @@ es:
       long_date_time: '%A %d %B %Y at %H:%M'
       from_long_date_time: 'From %A %d %B %Y at %H:%M'
       until_long_date_time: 'Until %A %d %B %Y at %H:%M'
+      from_long_date: 'From %A %d %B %Y'
+      until_long_date: 'Until %A %d %B %Y'
       weekday: '%A'
       month: '%B'
       dayandmonth: '%d/%m'

--- a/config/locales/dates/dates.fr-FR.yml
+++ b/config/locales/dates/dates.fr-FR.yml
@@ -92,6 +92,8 @@ fr:
       long_date_time: '%A %d %B %Y à %I:%M %p'
       from_long_date_time: 'De %A %d %B %Y à %I:%M %p'
       until_long_date_time: 'Jusque %A %d %B %Y à %I:%M %p'
+      from_long_date: 'De %A %d %B %Y'
+      until_long_date: 'Jusque %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a à %I:%M %p'

--- a/config/locales/dates/dates.hu-HU.yml
+++ b/config/locales/dates/dates.hu-HU.yml
@@ -35,6 +35,8 @@ hu:
       long_date_time: '%d %B %Y %B %d (%A) %H:%M'
       from_long_date_time: '%Y %B %d (%A) %H:%M -tól'
       until_long_date_time: '%Y %B %d (%A) %H:%M -ig'
+      from_long_date: '%Y %B %d (%A) -tól'
+      until_long_date: '%Y %B %d (%A) -ig'
       short: '%Y. %b. %d.'
       two_rows: '%Y %b %d <br/> %H:%M'
       weekday: '%a %H:%M'

--- a/config/locales/dates/dates.id-ID.yml
+++ b/config/locales/dates/dates.id-ID.yml
@@ -87,6 +87,8 @@ id:
       long_date_time: '%A %d %B %Y pada %I:%M %p'
       from_long_date_time: 'Dari %A %d %B %Y pada %I:%M %p'
       until_long_date_time: 'Hingga %A %d %B %Y pada %I:%M %p'
+      from_long_date: 'Dari %A %d %B %Y'
+      until_long_date: 'Hingga %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a pada %I:%M %p'

--- a/config/locales/dates/dates.it-IT.yml
+++ b/config/locales/dates/dates.it-IT.yml
@@ -87,6 +87,8 @@ it:
       long_date_time: '%A %d %B %Y ore %H:%M'
       from_long_date_time: 'Da %A %d %B %Y alle %H:%M'
       until_long_date_time: 'Fino a %A %d %B %Y alle %H:%M'
+      from_long_date: 'Da %A %d %B %Y'
+      until_long_date: 'Fino %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %H:%M'
       weekday: '%a alle %H:%M'

--- a/config/locales/dates/dates.me-ME.yml
+++ b/config/locales/dates/dates.me-ME.yml
@@ -87,6 +87,8 @@ me:
       long_date_time: '%A %d %B %Y u %I:%M %p'
       from_long_date_time: 'Od %A %d %B %Y u %I:%M %p'
       until_long_date_time: 'Do %A %d %B %Y u %I:%M %p'
+      from_long_date: 'Od %A %d %B %Y'
+      until_long_date: 'Do %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a u %I:%M %p'

--- a/config/locales/dates/dates.pt-PT.yml
+++ b/config/locales/dates/dates.pt-PT.yml
@@ -45,6 +45,8 @@ pt:
       long_date_time: '%A %d %B %Y às %I:%M %p'
       from_long_date_time: 'De %A %d %B %Y a %I:%M %p'
       until_long_date_time: 'De %A %d %B %Y a %I:%M %p'
+      from_long_date: 'De %A %d %B %Y'
+      until_long_date: 'De %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a a %I:%M %p'

--- a/config/locales/dates/dates.ro-RO.yml
+++ b/config/locales/dates/dates.ro-RO.yml
@@ -38,6 +38,8 @@ ro:
       long_date_time: '%A %d %B %Y at %H:%M'
       from_long_date_time: 'From %A %d %B %Y at %H:%M'
       until_long_date_time: 'Until %A %d %B %Y at %H:%M'
+      from_long_date: 'From %A %d %B %Y'
+      until_long_date: 'Until %A %d %B %Y'
       weekday: '%A'
       textfield: '%d/%m/%Y %H:%M'
   datetime:

--- a/config/locales/dates/dates.ru-RU.yml
+++ b/config/locales/dates/dates.ru-RU.yml
@@ -76,6 +76,8 @@ ru:
       long_date_time: '%A %d %B %Y at %I:%M %p'
       from_long_date_time: 'С %A %d %B %Y в %I:%M %p'
       until_long_date_time: 'По %A %d %B %Y в %I:%M %p'
+      from_long_date: 'С %A %d %B %Y'
+      until_long_date: 'По %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a at %I:%M %p'

--- a/config/locales/dates/dates.sr-SP.yml
+++ b/config/locales/dates/dates.sr-SP.yml
@@ -87,6 +87,8 @@ sr:
       long_date_time: '%A %d %B %Y у %I:%M %p'
       from_long_date_time: 'Од %A %d %B %Y у %I:%M %p'
       until_long_date_time: 'Дo %A %d %B %Y у %I:%M %p'
+      from_long_date: 'Од %A %d %B %Y'
+      until_long_date: 'Дo %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a у %I:%M %p'

--- a/config/locales/dates/dates.zh-TW.yml
+++ b/config/locales/dates/dates.zh-TW.yml
@@ -18,6 +18,8 @@ zh:
       long_date_time: '%A %d %B %Y at %I:%M %p'
       from_long_date_time: 'From %A %d %B %Y at %I:%M %p'
       until_long_date_time: 'To %A %d %B %Y at %I:%M %p'
+      from_long_date: 'From %A %d %B %Y'
+      until_long_date: 'To %A %d %B %Y'
       short: '%d %b %Y'
       two_rows: '%d %b %Y <br/> %I:%M %p'
       weekday: '%a at %I:%M %p'


### PR DESCRIPTION
* Implement switching between date and date & time formats in foundation datetimepicker  
But I'm not sure that I've placed js events in correct files, check it please
* Update locales to prevent time from displaying in all day events  
**IMPORTANT!**
I'm not able to generate changes for **dates.crowdin.yml**
Hope someone with access to crowdin account will finish it =)  
Need to add **from_long_date** and **until_long_date** (with the same content as in other locales)