### PR TITLE
#1451 New layout for events in lists

### DIFF
--- a/app/assets/stylesheets/event.css.scss
+++ b/app/assets/stylesheets/event.css.scss
@@ -1,44 +1,79 @@
-
-.event_calendar {
-  background: asset_url("calendar.png") no-repeat;
-  width: 64px;
-  height: 64px;
-  cursor: default;
+.event-date {
+  width: 6rem;
+  margin: 0 auto 0.6rem;
+  display: table-cell;
+  width: auto;
   float: left;
-  .day {
-    font-size: 11px;
-    margin: auto;
-    padding-top: 16px;
+  padding-right: 10px;
+
+  .event-month {
+    margin: 0;
+    background: #eee;
+    padding: 0.5rem 2rem;
     text-align: center;
   }
-  .number {
-    font-size: 22px;
-    font-weight: bold;
-    margin-top: -6px;
+
+  .event-day {
+    margin: 0;
+    border: 1px solid #eee;
+    padding: 0 2rem;
     text-align: center;
+    font-size: 2rem;
   }
 }
 
-.event_calendar_mini {
-  background: asset_url("calendar-32.png") no-repeat;
-  width: 32px;
-  height: 32px;
-  cursor: pointer;
+.event_dates_text {
   float: left;
-  margin-top: -18px;
-  .day {
-    font-size: 10px;
-    margin: auto;
-    padding-top: 14px;
-    text-align: center;
+  margin-top: 17px;
+}
+
+.event-desc {
+  padding: 0 0 0 1rem;
+  text-align: left;
+  display: table-cell;
+  vertical-align: top;
+
+  .event-desc-header {
+    margin: 0 0 0.5rem 0;
+    padding: 0;
   }
-  .number {
-    font-size: 20px;
+
+  .event-desc-detail {
+    margin: 0 0 0.25rem;
+    padding: 0;
+  }
+
+  .event-desc-time {
     font-weight: bold;
-    margin-top: -5px;
-    text-align: center;
+  }
+
+  .rsvp.button {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    margin: 0;
   }
 }
+
+// .event_calendar_mini {
+//   background: asset_url("calendar-32.png") no-repeat;
+//   width: 32px;
+//   height: 32px;
+//   cursor: pointer;
+//   float: left;
+//   margin-top: -18px;
+//   .day {
+//     font-size: 10px;
+//     margin: auto;
+//     padding-top: 14px;
+//     text-align: center;
+//   }
+//   .number {
+//     font-size: 20px;
+//     font-weight: bold;
+//     margin-top: -5px;
+//     text-align: center;
+//   }
+// }
 
 .event-overview {
   background-color: white;
@@ -58,7 +93,7 @@
 
 .mini_event {
   border-bottom: 1px dotted #ccc;
-  margin-bottom: 2px;
+  margin-bottom: 6px;
   margin-top: 2px;
 }
 

--- a/app/views/events/_calendar_icon.html.erb
+++ b/app/views/events/_calendar_icon.html.erb
@@ -1,8 +1,8 @@
-<div class="event_calendar" style="margin-right:10px;">
-  <div class="day">
+<div class="event-date">
+  <p class="event-month">
     <%=l time, format: :month%>
-  </div>
-  <div class="number">
+  </p>
+  <p class="event-day">
     <%= time.mday %>
-  </div>
+  </p>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,7 +29,7 @@
         </div>
         <div class="event_content">
           <%= render partial: 'events/calendar_icon', locals: {time: @event.starttime} %>
-          <div style="float:left;margin-top: 10px;">
+          <div class="event_dates_text">
             <meta itemprop="startDate" content="<%= l @event.starttime, format: '%Y-%m-%dT%H:%M' %>">
             <b>
               <%= @event.formatted_starttime %>


### PR DESCRIPTION
Use http://zurb.com/building-blocks/event-listing instead of current implementation
**events#show**
![screenshot from 2015-08-25 22 08 04](https://cloud.githubusercontent.com/assets/3235487/9476845/a2e081e2-4b77-11e5-8901-116e1dccd366.png)
**groups#show (next events)**
![screenshot from 2015-08-25 22 18 15](https://cloud.githubusercontent.com/assets/3235487/9476848/a47fd840-4b77-11e5-9787-500bf8d9d5be.png)
**home#index ? (next events, user homepage)**
![screenshot from 2015-08-25 22 18 46](https://cloud.githubusercontent.com/assets/3235487/9476852/a601458c-4b77-11e5-8286-3ca78c40628a.png)

